### PR TITLE
Update for angular 1.7 support. In 1.7 href='javascript:;' is deemed …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 reporters
 *.iml
 npm-debug.log
+yarn.lock

--- a/src/angularVerticalTree.tpl.html
+++ b/src/angularVerticalTree.tpl.html
@@ -3,7 +3,7 @@
 
     <!-- .panel-heading by default -->
     <a class="v-tree-breadcrumb"
-       href="javascript:;"
+       href=""
        ng-class="opts.classes.breadcrumb"
        ng-click="breadcrumbClickHandler( breadcrumb, $index )"
        ng-include="templates.breadcrumb"
@@ -15,7 +15,7 @@
     <div class="v-tree-branch" ng-class="opts.classes.branch">
         <!-- .list-group-item by default -->
         <a class="v-tree-leaf"
-           href="javascript:;"
+           href=""
            ng-class="opts.classes.leaf"
            ng-click="leafClickHandler( leaf )"
            ng-include="templates.leaf"


### PR DESCRIPTION
…unsafe and gets prepended with unsafe: prefix. This causes the link to try to navigate to unsafe:javascript:; which causes issues.